### PR TITLE
Add repeat detector block

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -18,5 +18,6 @@
 # Boston, MA 02110-1301, USA.
 
 install(FILES
-    reveng_pattern_dump.xml DESTINATION share/gnuradio/grc/blocks
+    reveng_pattern_dump.xml
+    reveng_repeat_detector.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/reveng_repeat_detector.xml
+++ b/grc/reveng_repeat_detector.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<block>
+  <name>Repeat detector</name>
+  <key>reveng_repeat_detector</key>
+  <category>reveng</category>
+  <import>import reveng</import>
+  <make>reveng.repeat_detector()</make>
+  <sink>
+    <name>pdus</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+</block>

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,7 +31,8 @@ endif()
 GR_PYTHON_INSTALL(
     FILES
     __init__.py
-    pattern_dump.py DESTINATION ${GR_PYTHON_DIR}/reveng
+    pattern_dump.py
+    repeat_detector.py DESTINATION ${GR_PYTHON_DIR}/reveng
 )
 
 ########################################################################
@@ -41,3 +42,4 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-reveng)
 set(GR_TEST_PYTHON_DIRS ${CMAKE_BINARY_DIR}/swig)
+GR_ADD_TEST(qa_repeat_detector ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_repeat_detector.py)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -46,6 +46,7 @@ if _RTLD_GLOBAL != 0:
 
 # import any pure python here
 from pattern_dump import pattern_dump
+from repeat_detector import repeat_detector
 #
 
 # ----------------------------------------------------------------

--- a/python/qa_repeat_detector.py
+++ b/python/qa_repeat_detector.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2016 Mike Walters.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+import pmt
+from repeat_detector import repeat_detector
+
+class qa_repeat_detector (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001 (self):
+        # just check it can run
+        rd = repeat_detector()
+        rd.handler(pmt.to_pmt((None, "1010")))
+        rd.handler(pmt.to_pmt((None, "1010")))
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_repeat_detector, "qa_repeat_detector.xml")

--- a/python/repeat_detector.py
+++ b/python/repeat_detector.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2016 Mike Walters.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+import numpy
+from gnuradio import gr
+import pmt
+import sys
+
+class repeat_detector(gr.sync_block):
+    """
+    Take PDUs as input and print them to stdout.
+    If the current PDU matches the previous one then print '.' instead.
+    """
+    def __init__(self):
+        gr.sync_block.__init__(self,
+            name="repeat_detector",
+            in_sig=None,
+            out_sig=None)
+        self.message_port_register_in(pmt.intern("pdus"))
+        self.set_msg_handler(pmt.intern("pdus"), self.handler)
+        self.prev_msg = None
+
+    def handler(self, pdu):
+        msg = pmt.to_python(pdu)[1]
+        if self.prev_msg != msg:
+            sys.stdout.write("\n" + msg + ' ')
+            self.prev_msg = msg
+        else:
+            sys.stdout.write('.')
+        sys.stdout.flush()
+
+
+    def work(self, input_items, output_items):
+        pass
+


### PR DESCRIPTION
This block takes the PDU output from `pattern_dump` and prints the data to stdout. If the new data is identical to the previous data then it just prints a `.`, giving an idea of how many times that packet repeated.
##### Example flowgraph and output:

![repeat-detector-example](https://cloud.githubusercontent.com/assets/578095/15088884/60ece4b8-13f1-11e6-9916-2dde555960ab.png)

```
11100000010110101110101100000110100000000001000000001011100011101101111000011000111 .......
11100000010110101110101100000110100000000001000000001011100011101111111000011000111 
```

This shows a packet being received and then repeating 7 more times (probably correctly decoded), then the packet comes through again with a bit flip and no repeats (probably not correctly decoded).

I'm finding this useful for giving me some confidence in my packet reversing in the early stages, until I have a CRC figured out.
