### PR TITLE
Port pattern_dump to C++

### DIFF
--- a/include/reveng/CMakeLists.txt
+++ b/include/reveng/CMakeLists.txt
@@ -22,5 +22,5 @@
 ########################################################################
 install(FILES
     api.h
-    DESTINATION include/reveng
+    pattern_dump.h DESTINATION include/reveng
 )

--- a/include/reveng/pattern_dump.h
+++ b/include/reveng/pattern_dump.h
@@ -1,0 +1,57 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2014-2015 tkuester.
+ * Copyright 2016 Mike Walters.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_REVENG_PATTERN_DUMP_H
+#define INCLUDED_REVENG_PATTERN_DUMP_H
+
+#include <reveng/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace reveng {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup reveng
+     *
+     */
+    class REVENG_API pattern_dump : virtual public gr::sync_block
+    {
+     public:
+      typedef boost::shared_ptr<pattern_dump> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of reveng::pattern_dump.
+       *
+       * To avoid accidental use of raw pointers, reveng::pattern_dump's
+       * constructor is in a private implementation
+       * class. reveng::pattern_dump::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time = true, const char *file_name = 0, bool stdout = true);
+    };
+
+  } // namespace reveng
+} // namespace gr
+
+#endif /* INCLUDED_REVENG_PATTERN_DUMP_H */
+

--- a/include/reveng/pattern_dump.h
+++ b/include/reveng/pattern_dump.h
@@ -47,7 +47,7 @@ namespace gr {
        * class. reveng::pattern_dump::make is the public interface for
        * creating new instances.
        */
-      static sptr make(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time = true, const char *file_name = 0, bool stdout = true);
+      static sptr make(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time = true, const char *file_name = "", bool stdout = true);
     };
 
   } // namespace reveng

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIRS})
 
 list(APPEND reveng_sources
+    pattern_dump_impl.cc
 )
 
 set(reveng_sources "${reveng_sources}" PARENT_SCOPE)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,21 @@
 # Boston, MA 02110-1301, USA.
 
 ########################################################################
+# C++11
+########################################################################
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+else()
+        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
+########################################################################
 # Setup library
 ########################################################################
 include(GrPlatform) #define LIB_SUFFIX

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -130,6 +130,23 @@ namespace gr {
     }
 
     std::string
+    pattern_dump_impl::get_output_man_string()
+    {
+      std::string out("");
+      auto bitstring = get_output_bit_string();
+      for (int i = 0; i < bitstring.length(); i += 2) {
+        auto symbol = bitstring.substr(i, 2);
+        if (symbol == "01")
+          out += "0";
+        else if (symbol == "10")
+          out += "1";
+        else
+          out += "x";
+      }
+      return out;
+    }
+
+    std::string
     pattern_dump_impl::get_output_pwm_string()
     {
       std::string out("");
@@ -165,6 +182,7 @@ namespace gr {
 
       boost::replace_all(out, "%[bits]", get_output_bit_string());
       boost::replace_all(out, "%[hex]", get_output_hex_string());
+      boost::replace_all(out, "%[man-bits]", get_output_man_string());
       boost::replace_all(out, "%[pwm-bits]", get_output_pwm_string());
       return out;
     }

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -118,6 +118,18 @@ namespace gr {
     }
 
     std::string
+    pattern_dump_impl::get_output_hex_string()
+    {
+      auto bitstring = get_output_bit_string();
+      std::stringstream ss;
+      ss << std::uppercase << std::setfill('0') << std::hex;
+      for (int i = 0; i < bitstring.length(); i += 8) {
+        ss << std::setw(2) << std::bitset<8>(bitstring.substr(i, 8)).to_ulong();
+      }
+      return ss.str();
+    }
+
+    std::string
     pattern_dump_impl::format_output()
     {
       std::time_t t = std::time(nullptr);
@@ -133,7 +145,9 @@ namespace gr {
         std::strftime(buf, sizeof(buf), d_output_fmt.c_str(), std::localtime(&t));
         out = std::string(buf);
       }
+
       boost::replace_all(out, "%[bits]", get_output_bit_string());
+      boost::replace_all(out, "%[hex]", get_output_hex_string());
       return out;
     }
 

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -69,6 +69,12 @@ namespace gr {
     {
     }
 
+    bool
+    pattern_dump_impl::start()
+    {
+      d_start_time = std::chrono::steady_clock::now();
+    }
+
     int
     pattern_dump_impl::work(int noutput_items,
         gr_vector_const_void_star &input_items,
@@ -115,9 +121,18 @@ namespace gr {
     pattern_dump_impl::format_output()
     {
       std::time_t t = std::time(nullptr);
-      char buf[512];
-      std::strftime(buf, sizeof(buf), d_output_fmt.c_str(), std::localtime(&t));
-      auto out = std::string(buf);
+      std::string out;
+      if (d_rel_time) {
+        out = d_output_fmt;
+        auto now = std::chrono::steady_clock::now();
+        std::chrono::duration<float> elapsed = now - d_start_time;
+        auto rel_time = elapsed.count();
+        boost::replace_all(out, "%s", std::to_string(rel_time));
+      } else {
+        char buf[512];
+        std::strftime(buf, sizeof(buf), d_output_fmt.c_str(), std::localtime(&t));
+        out = std::string(buf);
+      }
       boost::replace_all(out, "%[bits]", get_output_bit_string());
       return out;
     }

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -42,8 +42,22 @@ namespace gr {
     pattern_dump_impl::pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout)
       : gr::sync_block("pattern_dump",
               gr::io_signature::make(1, 1, sizeof(unsigned char)),
-              gr::io_signature::make(0, 0, 0))
-    {}
+              gr::io_signature::make(0, 0, 0)),
+        d_rel_time(rel_time),
+        d_stdout(stdout),
+        d_pattern(pattern.size()),
+        d_pattern_check(pattern.size()),
+        d_output(dump_len),
+        d_pattern_check_len(0),
+        d_output_len(0)
+    {
+      // Copy pattern vector to bitset
+      int i = pattern.size() - 1;
+      for (auto bit : pattern)
+        d_pattern[i--] = bit;
+
+      message_port_register_out(port_id);
+    }
 
     /*
      * Our virtual destructor.
@@ -59,10 +73,40 @@ namespace gr {
     {
       const unsigned char *in = (const unsigned char *) input_items[0];
 
-      // Do <+signal processing+>
+      for (int i = 0; i < noutput_items; i++) {
+        bool bit = in[i];
+        if (d_pattern_check_len == d_pattern_check.size() && d_pattern_check == d_pattern) {
+          shift_bit(d_output, bit);
+          d_output_len++;
+
+          if (d_output_len == d_output.size()) {
+            std::string out;
+            boost::to_string(d_output, out);
+            auto msg = pmt::cons(pmt::PMT_NIL, pmt::intern(out));
+            message_port_pub(port_id, msg);
+
+            if (d_stdout)
+              std::cout << out << std::endl;
+
+            d_output_len = 0;
+            d_pattern_check_len = 0;
+          }
+
+        } else {
+          shift_bit(d_pattern_check, bit);
+          d_pattern_check_len = std::min(d_pattern_check_len + 1, (int)d_pattern_check.size());
+        }
+      }
 
       // Tell runtime system how many output items we produced.
       return noutput_items;
+    }
+
+    void
+    pattern_dump_impl::shift_bit(boost::dynamic_bitset<> &bitset, bool bit)
+    {
+      bitset <<= 1;
+      bitset[0] = bit;
     }
 
   } /* namespace reveng */

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -1,0 +1,70 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2014-2015 tkuester.
+ * Copyright 2016 Mike Walters.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "pattern_dump_impl.h"
+
+namespace gr {
+  namespace reveng {
+
+    pattern_dump::sptr
+    pattern_dump::make(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout)
+    {
+      return gnuradio::get_initial_sptr
+        (new pattern_dump_impl(pattern, dump_len, output_fmt, rel_time, file_name, stdout));
+    }
+
+    /*
+     * The private constructor
+     */
+    pattern_dump_impl::pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout)
+      : gr::sync_block("pattern_dump",
+              gr::io_signature::make(1, 1, sizeof(unsigned char)),
+              gr::io_signature::make(0, 0, 0))
+    {}
+
+    /*
+     * Our virtual destructor.
+     */
+    pattern_dump_impl::~pattern_dump_impl()
+    {
+    }
+
+    int
+    pattern_dump_impl::work(int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items)
+    {
+      const unsigned char *in = (const unsigned char *) input_items[0];
+
+      // Do <+signal processing+>
+
+      // Tell runtime system how many output items we produced.
+      return noutput_items;
+    }
+
+  } /* namespace reveng */
+} /* namespace gr */
+

--- a/lib/pattern_dump_impl.cc
+++ b/lib/pattern_dump_impl.cc
@@ -130,6 +130,23 @@ namespace gr {
     }
 
     std::string
+    pattern_dump_impl::get_output_pwm_string()
+    {
+      std::string out("");
+      auto bitstring = get_output_bit_string();
+      for (int i = 0; i < bitstring.length(); i += 3) {
+        auto symbol = bitstring.substr(i, 3);
+        if (symbol == "100")
+          out += "1";
+        else if (symbol == "110")
+          out += "0";
+        else
+          out += "x";
+      }
+      return out;
+    }
+
+    std::string
     pattern_dump_impl::format_output()
     {
       std::time_t t = std::time(nullptr);
@@ -148,6 +165,7 @@ namespace gr {
 
       boost::replace_all(out, "%[bits]", get_output_bit_string());
       boost::replace_all(out, "%[hex]", get_output_hex_string());
+      boost::replace_all(out, "%[pwm-bits]", get_output_pwm_string());
       return out;
     }
 

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -31,6 +31,7 @@ namespace gr {
     class pattern_dump_impl : public pattern_dump
     {
      private:
+      std::string d_output_fmt;
       bool d_rel_time;
       bool d_stdout;
       pmt::pmt_t port_id = pmt::mp("out");
@@ -41,6 +42,8 @@ namespace gr {
       int d_pattern_check_len;
       int d_output_len;
 
+      std::string get_output_bit_string();
+      std::string format_output();
       void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);
 
      public:

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -24,6 +24,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 #include <chrono>
+#include <cstdio>
 #include <reveng/pattern_dump.h>
 
 namespace gr {
@@ -43,6 +44,8 @@ namespace gr {
       int d_pattern_check_len;
       int d_output_len;
 
+      FILE *d_output_file = nullptr;
+
       std::chrono::steady_clock::time_point d_start_time;
 
       std::string get_output_bit_string();
@@ -56,12 +59,13 @@ namespace gr {
       pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout);
       ~pattern_dump_impl();
 
-      bool start();
+      bool start() override;
+      bool stop() override;
 
       // Where all the action really happens
       int work(int noutput_items,
          gr_vector_const_void_star &input_items,
-         gr_vector_void_star &output_items);
+         gr_vector_void_star &output_items) override;
     };
 
   } // namespace reveng

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -47,6 +47,7 @@ namespace gr {
 
       std::string get_output_bit_string();
       std::string get_output_hex_string();
+      std::string get_output_man_string();
       std::string get_output_pwm_string();
       std::string format_output();
       void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -47,6 +47,7 @@ namespace gr {
 
       std::string get_output_bit_string();
       std::string get_output_hex_string();
+      std::string get_output_pwm_string();
       std::string format_output();
       void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);
 

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -23,6 +23,7 @@
 #define INCLUDED_REVENG_PATTERN_DUMP_IMPL_H
 
 #include <boost/dynamic_bitset.hpp>
+#include <chrono>
 #include <reveng/pattern_dump.h>
 
 namespace gr {
@@ -42,6 +43,8 @@ namespace gr {
       int d_pattern_check_len;
       int d_output_len;
 
+      std::chrono::steady_clock::time_point d_start_time;
+
       std::string get_output_bit_string();
       std::string format_output();
       void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);
@@ -49,6 +52,8 @@ namespace gr {
      public:
       pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout);
       ~pattern_dump_impl();
+
+      bool start();
 
       // Where all the action really happens
       int work(int noutput_items,

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -1,0 +1,49 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2014-2015 tkuester.
+ * Copyright 2016 Mike Walters.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_REVENG_PATTERN_DUMP_IMPL_H
+#define INCLUDED_REVENG_PATTERN_DUMP_IMPL_H
+
+#include <reveng/pattern_dump.h>
+
+namespace gr {
+  namespace reveng {
+
+    class pattern_dump_impl : public pattern_dump
+    {
+     private:
+      // Nothing to declare in this block.
+
+     public:
+      pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout);
+      ~pattern_dump_impl();
+
+      // Where all the action really happens
+      int work(int noutput_items,
+         gr_vector_const_void_star &input_items,
+         gr_vector_void_star &output_items);
+    };
+
+  } // namespace reveng
+} // namespace gr
+
+#endif /* INCLUDED_REVENG_PATTERN_DUMP_IMPL_H */
+

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -22,6 +22,7 @@
 #ifndef INCLUDED_REVENG_PATTERN_DUMP_IMPL_H
 #define INCLUDED_REVENG_PATTERN_DUMP_IMPL_H
 
+#include <boost/dynamic_bitset.hpp>
 #include <reveng/pattern_dump.h>
 
 namespace gr {
@@ -30,7 +31,17 @@ namespace gr {
     class pattern_dump_impl : public pattern_dump
     {
      private:
-      // Nothing to declare in this block.
+      bool d_rel_time;
+      bool d_stdout;
+      pmt::pmt_t port_id = pmt::mp("out");
+      boost::dynamic_bitset<> d_pattern;
+      boost::dynamic_bitset<> d_pattern_check;
+      boost::dynamic_bitset<> d_output;
+
+      int d_pattern_check_len;
+      int d_output_len;
+
+      void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);
 
      public:
       pattern_dump_impl(const std::vector<unsigned char> &pattern, unsigned int dump_len, const char *output_fmt, bool rel_time, const char *file_name, bool stdout);

--- a/lib/pattern_dump_impl.h
+++ b/lib/pattern_dump_impl.h
@@ -46,6 +46,7 @@ namespace gr {
       std::chrono::steady_clock::time_point d_start_time;
 
       std::string get_output_bit_string();
+      std::string get_output_hex_string();
       std::string format_output();
       void shift_bit(boost::dynamic_bitset<> &bitset, bool bit);
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,3 +41,4 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-reveng)
 set(GR_TEST_PYTHON_DIRS ${CMAKE_BINARY_DIR}/swig)
+GR_ADD_TEST(qa_pattern_dump ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_pattern_dump.py)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -30,8 +30,7 @@ endif()
 ########################################################################
 GR_PYTHON_INSTALL(
     FILES
-    __init__.py
-    pattern_dump.py DESTINATION ${GR_PYTHON_DIR}/reveng
+    __init__.py DESTINATION ${GR_PYTHON_DIR}/reveng
 )
 
 ########################################################################

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -42,10 +42,9 @@ if _RTLD_GLOBAL != 0:
 
 
 # import swig generated symbols into the reveng namespace
-#from reveng_swig import *
+from reveng_swig import *
 
 # import any pure python here
-from pattern_dump import pattern_dump
 #
 
 # ----------------------------------------------------------------

--- a/python/qa_pattern_dump.py
+++ b/python/qa_pattern_dump.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2016 Mike Walters.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+from pattern_dump import pattern_dump
+
+class qa_pattern_dump(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block ()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_t(self):
+        # set up fg
+        self.tb.run ()
+        # check data
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_pattern_dump, "qa_pattern_dump.xml")

--- a/python/qa_pattern_dump.py
+++ b/python/qa_pattern_dump.py
@@ -22,7 +22,7 @@
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
 import pmt
-from pattern_dump import pattern_dump
+import reveng_swig as reveng
 
 class qa_pattern_dump(gr_unittest.TestCase):
 
@@ -35,7 +35,7 @@ class qa_pattern_dump(gr_unittest.TestCase):
 
     def get_matches(self, src_data, pattern, dump_len):
         src = blocks.vector_source_b(src_data)
-        pd = pattern_dump(pattern, dump_len, "%[bits]", True, None, False)
+        pd = reveng.pattern_dump(pattern, dump_len, "%[bits]", True, None, False)
         self.tb.connect(src, pd)
         self.tb.msg_connect(pd, "out", self.dbg, "store")
         self.tb.run()

--- a/swig/reveng_swig.i
+++ b/swig/reveng_swig.i
@@ -8,6 +8,9 @@
 %include "reveng_swig_doc.i"
 
 %{
+#include "reveng/pattern_dump.h"
 %}
 
 
+%include "reveng/pattern_dump.h"
+GR_SWIG_BLOCK_MAGIC2(reveng, pattern_dump);


### PR DESCRIPTION
I've been using the python pattern_dump but ran into performance problems on a 1mbit stream. I've been working on this C++ port which runs much better.

Any interest? It's not ready yet, but just wanted to start the discussion.

From the comment in the other PR about splitting functionality, maybe it would make sense to have pattern_dump in C++ and the formatting in python?
